### PR TITLE
Timer: Overrun timers now can miss their periods

### DIFF
--- a/source/vibe/core/core.d
+++ b/source/vibe/core/core.d
@@ -1111,15 +1111,13 @@ Timer createTimer(void delegate() nothrow @safe callback = null)
 				assert(m_running);
 				scope (exit) m_running = false;
 
-				do {
-					m_pendingFire = false;
-					m_callback();
+				m_pendingFire = false;
+				m_callback();
 
-					// make sure that no callbacks are fired after the timer
-					// has been actively stopped
-					if (m_pendingFire && !tm.pending)
-						m_pendingFire = false;
-				} while (m_pendingFire);
+				// make sure that no callbacks are fired after the timer
+				// has been actively stopped
+				if (m_pendingFire && !tm.pending)
+					m_pendingFire = false;
 			}, tm);
 		}
 	}


### PR DESCRIPTION
```
For example; if a timer with 1 sec period runs for 2.1 secs,
it will miss 2 periods and only be run at 1/3 Hz effectively.
```

test run;

```
        this.timers ~= this.taskman.setTimer(
                    1.seconds, () {
                        log.info("1 Hz timer");
                        this.taskman.wait(2100.msecs);
                    }, Periodic.Yes);
```

```
2022-01-27 12:43:18,989 Info [agora.node.FullNode] - 1 Hz timer
2022-01-27 12:43:21,989 Info [agora.node.FullNode] - 1 Hz timer
2022-01-27 12:43:22,989 Info [agora.network.Manager] - Doing periodic network discovery: 0 required peers requested, 0 missing, known 6
2022-01-27 12:43:24,989 Info [agora.node.FullNode] - 1 Hz timer
2022-01-27 12:43:27,989 Info [agora.network.Manager] - Doing periodic network discovery: 0 required peers requested, 0 missing, known 6
2022-01-27 12:43:27,989 Info [agora.node.FullNode] - 1 Hz timer
2022-01-27 12:43:30,988 Info [agora.node.FullNode] - 1 Hz timer
2022-01-27 12:43:32,989 Info [agora.network.Manager] - Doing periodic network discovery: 0 required peers requested, 0 missing, known 6
```

